### PR TITLE
IOS-5792: Add SPM dependencies support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ project.xcworkspace
 xcuserdata
 DerivedData/
 .build
-.swiftpm
 build
+xcuserdata/
 /protoc-gen-swift
 /protoc-gen-grpc-swift
 third_party/**
@@ -20,6 +20,5 @@ Examples/EchoWeb/package-lock.json
 dev/codegen-tests/**/generated/*
 /scripts/.swiftformat-source/
 /scripts/.swift-format-source/
-Package.resolved
 *.out.*
 /Performance/Benchmarks/.benchmarkBaselines/

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -120,10 +120,10 @@
     {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
+      "location" : "https://github.com/tangem/swift-protobuf.git",
       "state" : {
-        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
-        "version" : "1.25.2"
+        "branch" : "feature/IOS-5792-SPM-dependencies-support",
+        "revision" : "9e56dadd3a3d865bd6ff44847cfc27305dc7b55e"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -114,7 +114,7 @@
       "location" : "https://github.com/tangem/swift-protobuf-binaries.git",
       "state" : {
         "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "7f7a414b093735ab5431d6a45b73868bcd55d5ac"
+        "revision" : "bb1cf0deaa34d288ed74e7f47c5274915ed90213"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,149 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "49b7617717a09f6b781c9a11e1628e3315d8d4fe",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "12358d55a3824bd5fed310b999ea8cf83a9a1a65",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "635b2589494c97e48c62514bc8b37ced762e0a62",
+        "version" : "2.63.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "363da63c1966405764f380c627409b2f9d9e710b",
+        "version" : "1.21.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "0904bf0feb5122b7e5c3f15db7df0eabe623dd87",
+        "version" : "1.30.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "7c381eb6083542b124a6c18fae742f55001dc2b5",
+        "version" : "2.26.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce",
+        "version" : "1.20.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
+        "version" : "1.25.2"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "ce0141c8f123132dbd02fd45fea448018762df1b",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
+        "version" : "1.2.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "49b7617717a09f6b781c9a11e1628e3315d8d4fe",
-        "version" : "1.0.1"
-      }
-    },
-    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
@@ -124,15 +115,6 @@
       "state" : {
         "branch" : "feature/IOS-5792-SPM-dependencies-support",
         "revision" : "9e56dadd3a3d865bd6ff44847cfc27305dc7b55e"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "ce0141c8f123132dbd02fd45fea448018762df1b",
-        "version" : "1.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tangem/swift-protobuf-binaries.git",
       "state" : {
-        "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "bb1cf0deaa34d288ed74e7f47c5274915ed90213"
+        "revision" : "de30521530591d98be12133724e3d78bc0524e41",
+        "version" : "1.25.2-tangem1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -109,12 +109,12 @@
       }
     },
     {
-      "identity" : "swift-protobuf",
+      "identity" : "swift-protobuf-binaries",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tangem/swift-protobuf.git",
+      "location" : "https://github.com/tangem/swift-protobuf-binaries.git",
       "state" : {
         "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "9e56dadd3a3d865bd6ff44847cfc27305dc7b55e"
+        "revision" : "7f7a414b093735ab5431d6a45b73868bcd55d5ac"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/tangem/swift-protobuf-binaries.git",
-    branch: "feature/IOS-5792-SPM-dependencies-support"
+    exact: "1.25.2-tangem1"
   ),
   .package(
     url: "https://github.com/apple/swift-log.git",

--- a/Package.swift
+++ b/Package.swift
@@ -124,10 +124,6 @@ extension Target.Dependency {
     package: "swift-nio-transport-services"
   )
   static let logging: Self = .product(name: "Logging", package: "swift-log")
-  static let protobufPluginLibrary: Self = .product(
-    name: "SwiftProtobufPluginLibrary",
-    package: "swift-protobuf"
-  )
   static let protobuf: Self =  .product(name: "SwiftProtobuf", package: "swift-protobuf-binaries")
   static let dequeModule: Self = .product(name: "DequeModule", package: "swift-collections")
   static let atomics: Self = .product(name: "Atomics", package: "swift-atomics")
@@ -183,25 +179,6 @@ extension Target {
     path: "Sources/CGRPCZlib",
     linkerSettings: [
       .linkedLibrary("z"),
-    ]
-  )
-
-  static let protocGenGRPCSwift: Target = .executableTarget(
-    name: "protoc-gen-grpc-swift",
-    dependencies: [
-      .protobuf,
-      .protobufPluginLibrary,
-    ],
-    exclude: [
-      "README.md",
-    ]
-  )
-
-  static let grpcSwiftPlugin: Target = .plugin(
-    name: "GRPCSwiftPlugin",
-    capability: .buildTool(),
-    dependencies: [
-      .protocGenGRPCSwift,
     ]
   )
 
@@ -532,16 +509,6 @@ extension Product {
     name: "GRPCReflectionService",
     targets: ["GRPCReflectionService"]
   )
-
-  static let protocGenGRPCSwift: Product = .executable(
-    name: "protoc-gen-grpc-swift",
-    targets: ["protoc-gen-grpc-swift"]
-  )
-
-  static let grpcSwiftPlugin: Product = .plugin(
-    name: "GRPCSwiftPlugin",
-    targets: ["GRPCSwiftPlugin"]
-  )
 }
 
 // MARK: - Package
@@ -553,16 +520,12 @@ let package = Package(
     .grpcCore,
     .cgrpcZlib,
     .grpcReflectionService,
-    .protocGenGRPCSwift,
-    .grpcSwiftPlugin,
   ],
   dependencies: packageDependencies,
   targets: [
     // Products
     .grpc,
     .cgrpcZlib,
-    .protocGenGRPCSwift,
-    .grpcSwiftPlugin,
     .reflectionService,
 
     // Tests etc.

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let packageDependencies: [Package.Dependency] = [
     from: "1.2.0"
   ),
   .package(
-    url: "https://github.com/tangem/swift-protobuf.git",
+    url: "https://github.com/tangem/swift-protobuf-binaries.git",
     branch: "feature/IOS-5792-SPM-dependencies-support"
   ),
   .package(
@@ -124,11 +124,11 @@ extension Target.Dependency {
     package: "swift-nio-transport-services"
   )
   static let logging: Self = .product(name: "Logging", package: "swift-log")
-  static let protobuf: Self = .product(name: "SwiftProtobuf", package: "swift-protobuf")
   static let protobufPluginLibrary: Self = .product(
     name: "SwiftProtobufPluginLibrary",
     package: "swift-protobuf"
   )
+  static let protobuf: Self =  .product(name: "SwiftProtobuf", package: "swift-protobuf-binaries")
   static let dequeModule: Self = .product(name: "DequeModule", package: "swift-collections")
   static let atomics: Self = .product(name: "Atomics", package: "swift-atomics")
 

--- a/Package.swift
+++ b/Package.swift
@@ -55,8 +55,8 @@ let packageDependencies: [Package.Dependency] = [
     from: "1.2.0"
   ),
   .package(
-    url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.20.2"
+    url: "https://github.com/tangem/swift-protobuf.git",
+    branch: "feature/IOS-5792-SPM-dependencies-support"
   ),
   .package(
     url: "https://github.com/apple/swift-log.git",


### PR DESCRIPTION
[IOS-5792](https://tangem.atlassian.net/browse/IOS-5792)

- Форк, который использует binary xcframework `swift-protobuf-binaries` вместо обычного `SwiftProtobuf`
- Выпилены macos таргеты утилит генерации протобафов, потому что они не используются (мы не генерим протобафы, а юзаем уже готовые) и потому что их зависимостей нет в `swift-protobuf-binaries`
- Вернул `Package.resolved` в репу, чтобы был трекинг используемых версий зависимостей


[IOS-5792]: https://tangem.atlassian.net/browse/IOS-5792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ